### PR TITLE
Fix asset paths that are deeper than 1 level

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,11 +29,16 @@ export default function copy(options = { assets: [] }) {
       return Promise.all(
         assets.map(async asset => {
           try {
-            const target = path.join(outputDirectory, path.basename(asset));
-            const normalizedAssetPath = path.normalize(basedir, asset);
+            const assetChildPath = asset
+              .replace(
+                path.basename(basedir), 
+                ""
+              );
+            const target = path.join(outputDirectory, assetChildPath);
+            const normalizedAssetPath = path.normalize(basedir);
             const assetPath = path.join(
               normalizedAssetPath,
-              path.basename(asset)
+              assetChildPath
             );
             const targetIsDir = path.extname(target) === "";
             const targetExists = await fs.pathExists(target);


### PR DESCRIPTION
Currently, supplying an asset path more than 1 level will cause the rollup build to fail:

```js
copy({
	assets: [
		'src/index.html', // ok
		'src/raw/pdf', // will cause an error
	],
}),
```

The error in question:
```
(!) Plugin copy-assets: Could not copy src/raw/pdf because of an error: Error: ENOENT: no such file or directory, stat '{{my path}}\src\pdf'
```

Note how it's using the basename for the asset path instead of the full path, which is what this fixes.